### PR TITLE
Add static AdSense verification and Google CMP integration

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,13 +4,14 @@
     <meta charset="utf-8" />
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self' https://pagead2.googlesyndication.com 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://pagead2.googlesyndication.com; connect-src 'self'; font-src 'self' data:; frame-src https://googleads.g.doubleclick.net; base-uri 'self'; form-action 'self'; upgrade-insecure-requests"
+      content="default-src 'self'; script-src 'self' https://pagead2.googlesyndication.com https://fundingchoicesmessages.google.com https://www.gstatic.com 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://pagead2.googlesyndication.com https://tpc.googlesyndication.com; connect-src 'self' https://fundingchoicesmessages.google.com https://pagead2.googlesyndication.com https://googleads.g.doubleclick.net; font-src 'self' data:; frame-src https://googleads.g.doubleclick.net https://fundingchoicesmessages.google.com; base-uri 'self'; form-action 'self'; upgrade-insecure-requests"
     />
     <meta name="referrer" content="no-referrer-when-downgrade" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Stoppclock — Projector-friendly Timers & Clocks</title>
     <meta name="description" content="Analog countdown up to 12 hours, stopwatch, interval, world clock and more. Projector-friendly, offline-ready, minimal controls." />
     <link rel="canonical" href="https://www.stoppclock.com/"/>
+    <meta name="google-adsense-account" content="ca-pub-1712273263687132" />
 
     <!-- Open Graph (use your own hosted assets) -->
     <meta property="og:type" content="website"/>
@@ -37,19 +38,22 @@
     <link rel="apple-touch-icon" href="/icons/icon-180.png" />
     <link rel="stylesheet" href="/src/styles.css" />
 
+    <!-- Google Certified CMP -->
+    <script async src="https://fundingchoicesmessages.google.com/i/pub-1712273263687132?ers=1"></script>
+    <script>
+      window.googlefc = window.googlefc || {};
+      window.googlefc.callbackQueue = window.googlefc.callbackQueue || [];
+    </script>
+
+    <!-- Google AdSense (static verification + auto ads) -->
+    <script
+      async
+      src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-1712273263687132"
+      crossorigin="anonymous"
+    ></script>
+
   </head>
   <body>
-    <!-- Consent banner -->
-    <div id="consent" class="consent hidden">
-      <div class="consent-box">
-        <div><strong>Privacy first.</strong> Ads are <em>off</em> by default. Enable only if you agree.</div>
-        <div class="consent-actions">
-          <button id="consent-accept" class="btn primary">Enable Ads</button>
-          <button id="consent-decline" class="btn">Keep Off</button>
-        </div>
-      </div>
-    </div>
-
     <div id="root"></div>
 
     <!-- WebApplication JSON-LD -->
@@ -95,37 +99,6 @@
 
     <!-- App Entry -->
     <script type="module" src="/src/main.tsx"></script>
-
-    <!-- Consent-gated AdSense -->
-    <script>
-      document.addEventListener('DOMContentLoaded', function() {
-        const LS = "sc.adsConsent";
-        const has = localStorage.getItem(LS);
-        const el = document.getElementById('consent');
-        const acceptBtn = document.getElementById('consent-accept');
-        const declineBtn = document.getElementById('consent-decline');
-
-        function hideConsent(){ el?.classList.add('hidden'); }
-        function showConsent(){ el?.classList.remove('hidden'); }
-
-        function enableAds() {
-          const client = "ca-pub-1712273263687132";
-          if (!client || client.includes("REPLACE_ME")) { hideConsent(); return; }
-          const s = document.createElement('script');
-          s.async = true;
-          s.crossOrigin = "anonymous";
-          s.src = `https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=${encodeURIComponent(client)}`;
-          document.head.appendChild(s);
-        }
-
-        if (has === "yes") { enableAds(); hideConsent(); }
-        else if (has === "no") { hideConsent(); }
-        else { showConsent(); }
-
-        acceptBtn?.addEventListener("click", () => { localStorage.setItem(LS, "yes"); enableAds(); hideConsent(); });
-        declineBtn?.addEventListener("click", () => { localStorage.setItem(LS, "no"); hideConsent(); });
-      });
-    </script>
 
   </body>
 </html>

--- a/src/components/ads/ResponsiveAd.tsx
+++ b/src/components/ads/ResponsiveAd.tsx
@@ -1,0 +1,35 @@
+import { useEffect } from "react";
+import { ADSENSE_PUBLISHER_ID, HOME_TOP_SLOT_ID } from "../../config/ad-units";
+
+declare global {
+  interface Window {
+    adsbygoogle?: Array<Record<string, unknown>>;
+  }
+}
+
+const ResponsiveAd = () => {
+  useEffect(() => {
+    try {
+      (window.adsbygoogle = window.adsbygoogle || []).push({});
+    } catch (error) {
+      if (import.meta.env.DEV) {
+        console.warn("[AdSense] Unable to request ad slot", error);
+      }
+    }
+  }, []);
+
+  return (
+    <div className="ad-container" aria-label="Advertisement">
+      <ins
+        className="adsbygoogle"
+        style={{ display: "block" }}
+        data-ad-client={ADSENSE_PUBLISHER_ID}
+        data-ad-slot={HOME_TOP_SLOT_ID}
+        data-ad-format="auto"
+        data-full-width-responsive="true"
+      />
+    </div>
+  );
+};
+
+export default ResponsiveAd;

--- a/src/config/ad-units.ts
+++ b/src/config/ad-units.ts
@@ -6,13 +6,16 @@ import type { AdUnit } from '../types/monetization-types';
 // Google AdSense Publisher ID
 export const ADSENSE_PUBLISHER_ID = 'ca-pub-1712273263687132';
 
+// Primary responsive ad slot for the home page (replace with live slot once issued)
+export const HOME_TOP_SLOT_ID = '1234567890';
+
 // Ad unit configurations
 // Note: Ad slot IDs are placeholders - replace with actual IDs from AdSense dashboard
 export const AD_UNITS: AdUnit[] = [
   // Home page - top responsive ad between timer cards
   {
     unitId: 'home-top',
-    adSlotId: `${ADSENSE_PUBLISHER_ID}/1234567890`, // TODO: Replace with actual slot ID
+    adSlotId: HOME_TOP_SLOT_ID,
     placement: 'home',
     format: 'responsive',
     visibilityRules: {
@@ -25,7 +28,7 @@ export const AD_UNITS: AdUnit[] = [
   // Home page - middle responsive ad
   {
     unitId: 'home-middle',
-    adSlotId: `${ADSENSE_PUBLISHER_ID}/2345678901`,
+    adSlotId: '2345678901',
     placement: 'home',
     format: 'responsive',
     visibilityRules: {
@@ -38,7 +41,7 @@ export const AD_UNITS: AdUnit[] = [
   // Setup screens - sidebar/bottom responsive ad
   {
     unitId: 'setup-main',
-    adSlotId: `${ADSENSE_PUBLISHER_ID}/3456789012`,
+    adSlotId: '3456789012',
     placement: 'setup',
     format: 'responsive',
     visibilityRules: {
@@ -51,7 +54,7 @@ export const AD_UNITS: AdUnit[] = [
   // Timer completion interstitial
   {
     unitId: 'interstitial-complete',
-    adSlotId: `${ADSENSE_PUBLISHER_ID}/4567890123`,
+    adSlotId: '4567890123',
     placement: 'interstitial',
     format: 'responsive',
     visibilityRules: {
@@ -64,7 +67,7 @@ export const AD_UNITS: AdUnit[] = [
   // Anchor ad - bottom sticky
   {
     unitId: 'anchor-bottom',
-    adSlotId: `${ADSENSE_PUBLISHER_ID}/5678901234`,
+    adSlotId: '5678901234',
     placement: 'anchor',
     format: 'anchor',
     visibilityRules: {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -12,6 +12,7 @@ import CycleTimer from "./pages/CycleTimer";
 import DigitalClock from "./pages/DigitalClock";
 import Impressum from "./pages/Impressum";
 import Datenschutz from "./pages/Datenschutz";
+import ResponsiveAd from "./components/ads/ResponsiveAd";
 
 function useHashRoute() {
   const [, force] = React.useReducer((x) => x + 1, 0);
@@ -51,6 +52,7 @@ function Home() {
           </a>
         ))}
       </div>
+      <ResponsiveAd />
       <footer className="footer">
         <a href="#/impressum">Impressum</a>
         <span>•</span>

--- a/src/styles.css
+++ b/src/styles.css
@@ -88,30 +88,6 @@ body{
   font:16px/1.5 ui-sans-serif,system-ui,-apple-system,Segoe UI,Roboto;
 }
 
-/* Consent banner */
-.consent{
-  position:fixed;
-  z-index:9999;
-  inset:0;
-  background:rgba(0,0,0,.85);
-  display:grid;
-  place-items:center;
-  padding:20px;
-}
-.consent.hidden{ display:none; }
-.consent-box{
-  background:#1f2937;
-  padding:24px;
-  border-radius:12px;
-  max-width:480px;
-  box-shadow:0 12px 24px rgba(0,0,0,.4);
-}
-.consent-actions{
-  display:flex;
-  gap:12px;
-  margin-top:16px;
-}
-
 /* Home Title */
 .home-title{
   text-align:center;
@@ -167,6 +143,19 @@ body{
   gap:6px;
   width:100%;
   max-width:320px;
+}
+
+.ad-container{
+  margin:32px auto 12px;
+  max-width:960px;
+  width:100%;
+  padding:0 16px;
+}
+
+.ad-container > .adsbygoogle{
+  display:block !important;
+  width:100% !important;
+  min-height:90px;
 }
 
 .timer-card:hover{

--- a/src/types/monetization-types.ts
+++ b/src/types/monetization-types.ts
@@ -19,7 +19,7 @@ export interface ConsentPreference {
  */
 export interface AdUnit {
   unitId: string; // e.g., "home-top", "setup-sidebar"
-  adSlotId: string; // Google AdSense slot ID (ca-pub-XXXX/XXXXXX)
+  adSlotId: string; // Google AdSense slot ID (10-digit numeric string)
   placement: 'home' | 'setup' | 'interstitial' | 'anchor';
   format: 'responsive' | 'banner' | 'anchor';
   visibilityRules: {


### PR DESCRIPTION
## Summary
- add the Google-certified CMP script and static AdSense auto-ads snippet so verification runs without user interaction
- expose a responsive AdSense slot on the home page and supporting configuration for the primary ad unit
- clean up legacy consent UI styles while keeping layout ready for served ads

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68f619f79dc483229477bb3aab070a94